### PR TITLE
3 bam sensornet metadata sample

### DIFF
--- a/examples/static/embedded_sensornet.json
+++ b/examples/static/embedded_sensornet.json
@@ -15,15 +15,13 @@
                                 "measurement": "Relative Humidity",
                                 "unit": "%RH",
                                 "min": 0,
-                                "max": 100,
-                                "accuracy": 2
+                                "max": 100
                             },
                             {
                                 "measurement": "Temperature",
                                 "unit": "°C",
                                 "min": -40,
-                                "max": 125,
-                                "accuracy": 0.5
+                                "max": 125
                             }
                         ],
                         "calibration": {
@@ -51,15 +49,13 @@
                                 "measurement": "Pressure",
                                 "unit": "kPa",
                                 "min": 0,
-                                "max": 400,
-                                "accuracy": 1
+                                "max": 400
                             },
                             {
                                 "measurement": "Temperature",
                                 "unit": "°C",
                                 "min": -50,
-                                "max": 150,
-                                "accuracy": 5
+                                "max": 150
                             }
                         ],
                         "calibration": {
@@ -94,15 +90,13 @@
                                 "measurement": "Relative Humidity",
                                 "unit": "%RH",
                                 "min": 0,
-                                "max": 100,
-                                "accuracy": 2
+                                "max": 100
                             },
                             {
                                 "measurement": "Temperature",
                                 "unit": "°C",
                                 "min": -40,
-                                "max": 125,
-                                "accuracy": 0.5
+                                "max": 125
                             }
                         ],
                         "calibration": {
@@ -130,15 +124,13 @@
                                 "measurement": "Pressure",
                                 "unit": "kPa",
                                 "min": 0,
-                                "max": 400,
-                                "accuracy": 1
+                                "max": 400
                             },
                             {
                                 "measurement": "Temperature",
                                 "unit": "°C",
                                 "min": -50,
-                                "max": 150,
-                                "accuracy": 5
+                                "max": 150
                             }
                         ],
                         "calibration": {
@@ -173,15 +165,13 @@
                                 "measurement": "Relative Humidity",
                                 "unit": "%RH",
                                 "min": 0,
-                                "max": 100,
-                                "accuracy": 2
+                                "max": 100
                             },
                             {
                                 "measurement": "Temperature",
                                 "unit": "°C",
                                 "min": -40,
-                                "max": 125,
-                                "accuracy": 0.5
+                                "max": 125
                             }
                         ],
                         "calibration": {
@@ -209,15 +199,13 @@
                                 "measurement": "Pressure",
                                 "unit": "kPa",
                                 "min": 0,
-                                "max": 400,
-                                "accuracy": 1
+                                "max": 400
                             },
                             {
                                 "measurement": "Temperature",
                                 "unit": "°C",
                                 "min": -50,
-                                "max": 150,
-                                "accuracy": 5
+                                "max": 150
                             }
                         ],
                         "calibration": {
@@ -252,15 +240,13 @@
                                 "measurement": "Relative Humidity",
                                 "unit": "%RH",
                                 "min": 0,
-                                "max": 100,
-                                "accuracy": 2
+                                "max": 100
                             },
                             {
                                 "measurement": "Temperature",
                                 "unit": "°C",
                                 "min": -40,
-                                "max": 125,
-                                "accuracy": 0.5
+                                "max": 125
                             }
                         ],
                         "calibration": {
@@ -288,15 +274,13 @@
                                 "measurement": "Pressure",
                                 "unit": "kPa",
                                 "min": 0,
-                                "max": 400,
-                                "accuracy": 1
+                                "max": 400
                             },
                             {
                                 "measurement": "Temperature",
                                 "unit": "°C",
                                 "min": -50,
-                                "max": 150,
-                                "accuracy": 5
+                                "max": 150
                             }
                         ],
                         "calibration": {
@@ -331,15 +315,13 @@
                                 "measurement": "Relative Humidity",
                                 "unit": "%RH",
                                 "min": 0,
-                                "max": 100,
-                                "accuracy": 2
+                                "max": 100
                             },
                             {
                                 "measurement": "Temperature",
                                 "unit": "°C",
                                 "min": -40,
-                                "max": 125,
-                                "accuracy": 0.5
+                                "max": 125
                             }
                         ],
                         "calibration": {
@@ -367,15 +349,13 @@
                                 "measurement": "Pressure",
                                 "unit": "kPa",
                                 "min": 0,
-                                "max": 400,
-                                "accuracy": 1
+                                "max": 400
                             },
                             {
                                 "measurement": "Temperature",
                                 "unit": "°C",
                                 "min": -50,
-                                "max": 150,
-                                "accuracy": 5
+                                "max": 150
                             }
                         ],
                         "calibration": {

--- a/examples/static/embedded_sensornet.json
+++ b/examples/static/embedded_sensornet.json
@@ -31,8 +31,6 @@
                             "certificate": "BAM department 8.1"
                         },
                         "pose": {
-                            "body_frame": "",
-                            "rotation_order": "XYZ",
                             "position": [
                                 0,
                                 0,
@@ -69,8 +67,6 @@
                             "certificate": "BAM department 8.1"
                         },
                         "pose": {
-                            "body_frame": "",
-                            "rotation_order": "XYZ",
                             "position": [
                                 0,
                                 0,
@@ -114,8 +110,6 @@
                             "certificate": "BAM department 8.1"
                         },
                         "pose": {
-                            "body_frame": "",
-                            "rotation_order": "XYZ",
                             "position": [
                                 0,
                                 0,
@@ -152,8 +146,6 @@
                             "certificate": "BAM department 8.1"
                         },
                         "pose": {
-                            "body_frame": "",
-                            "rotation_order": "XYZ",
                             "position": [
                                 0,
                                 0,
@@ -197,8 +189,6 @@
                             "certificate": "BAM department 8.1"
                         },
                         "pose": {
-                            "body_frame": "",
-                            "rotation_order": "XYZ",
                             "position": [
                                 0,
                                 0,
@@ -235,8 +225,6 @@
                             "certificate": "BAM department 8.1"
                         },
                         "pose": {
-                            "body_frame": "",
-                            "rotation_order": "XYZ",
                             "position": [
                                 0,
                                 0,
@@ -280,8 +268,6 @@
                             "certificate": "BAM department 8.1"
                         },
                         "pose": {
-                            "body_frame": "",
-                            "rotation_order": "XYZ",
                             "position": [
                                 0,
                                 0,
@@ -318,8 +304,6 @@
                             "certificate": "BAM department 8.1"
                         },
                         "pose": {
-                            "body_frame": "",
-                            "rotation_order": "XYZ",
                             "position": [
                                 0,
                                 0,
@@ -363,8 +347,6 @@
                             "certificate": "BAM department 8.1"
                         },
                         "pose": {
-                            "body_frame": "",
-                            "rotation_order": "XYZ",
                             "position": [
                                 0,
                                 0,
@@ -401,8 +383,6 @@
                             "certificate": "BAM department 8.1"
                         },
                         "pose": {
-                            "body_frame": "",
-                            "rotation_order": "XYZ",
                             "position": [
                                 0,
                                 0,

--- a/examples/static/embedded_sensornet.json
+++ b/examples/static/embedded_sensornet.json
@@ -13,14 +13,14 @@
                         "measuring_quantity": [
                             {
                                 "measurement": "Relative Humidity",
-                                "measure_unit": "%RH",
+                                "unit": "%RH",
                                 "min": 0,
                                 "max": 100,
                                 "accuracy": 2
                             },
                             {
                                 "measurement": "Temperature",
-                                "measure_unit": "°C",
+                                "unit": "°C",
                                 "min": -40,
                                 "max": 125,
                                 "accuracy": 0.5
@@ -51,14 +51,14 @@
                         "measuring_quantity": [
                             {
                                 "measurement": "Pressure",
-                                "measure_unit": "kPa",
+                                "unit": "kPa",
                                 "min": 0,
                                 "max": 400,
                                 "accuracy": 1
                             },
                             {
                                 "measurement": "Temperature",
-                                "measure_unit": "°C",
+                                "unit": "°C",
                                 "min": -50,
                                 "max": 150,
                                 "accuracy": 5
@@ -96,14 +96,14 @@
                         "measuring_quantity": [
                             {
                                 "measurement": "Relative Humidity",
-                                "measure_unit": "%RH",
+                                "unit": "%RH",
                                 "min": 0,
                                 "max": 100,
                                 "accuracy": 2
                             },
                             {
                                 "measurement": "Temperature",
-                                "measure_unit": "°C",
+                                "unit": "°C",
                                 "min": -40,
                                 "max": 125,
                                 "accuracy": 0.5
@@ -134,14 +134,14 @@
                         "measuring_quantity": [
                             {
                                 "measurement": "Pressure",
-                                "measure_unit": "kPa",
+                                "unit": "kPa",
                                 "min": 0,
                                 "max": 400,
                                 "accuracy": 1
                             },
                             {
                                 "measurement": "Temperature",
-                                "measure_unit": "°C",
+                                "unit": "°C",
                                 "min": -50,
                                 "max": 150,
                                 "accuracy": 5
@@ -179,14 +179,14 @@
                         "measuring_quantity": [
                             {
                                 "measurement": "Relative Humidity",
-                                "measure_unit": "%RH",
+                                "unit": "%RH",
                                 "min": 0,
                                 "max": 100,
                                 "accuracy": 2
                             },
                             {
                                 "measurement": "Temperature",
-                                "measure_unit": "°C",
+                                "unit": "°C",
                                 "min": -40,
                                 "max": 125,
                                 "accuracy": 0.5
@@ -217,14 +217,14 @@
                         "measuring_quantity": [
                             {
                                 "measurement": "Pressure",
-                                "measure_unit": "kPa",
+                                "unit": "kPa",
                                 "min": 0,
                                 "max": 400,
                                 "accuracy": 1
                             },
                             {
                                 "measurement": "Temperature",
-                                "measure_unit": "°C",
+                                "unit": "°C",
                                 "min": -50,
                                 "max": 150,
                                 "accuracy": 5
@@ -262,14 +262,14 @@
                         "measuring_quantity": [
                             {
                                 "measurement": "Relative Humidity",
-                                "measure_unit": "%RH",
+                                "unit": "%RH",
                                 "min": 0,
                                 "max": 100,
                                 "accuracy": 2
                             },
                             {
                                 "measurement": "Temperature",
-                                "measure_unit": "°C",
+                                "unit": "°C",
                                 "min": -40,
                                 "max": 125,
                                 "accuracy": 0.5
@@ -300,14 +300,14 @@
                         "measuring_quantity": [
                             {
                                 "measurement": "Pressure",
-                                "measure_unit": "kPa",
+                                "unit": "kPa",
                                 "min": 0,
                                 "max": 400,
                                 "accuracy": 1
                             },
                             {
                                 "measurement": "Temperature",
-                                "measure_unit": "°C",
+                                "unit": "°C",
                                 "min": -50,
                                 "max": 150,
                                 "accuracy": 5
@@ -345,14 +345,14 @@
                         "measuring_quantity": [
                             {
                                 "measurement": "Relative Humidity",
-                                "measure_unit": "%RH",
+                                "unit": "%RH",
                                 "min": 0,
                                 "max": 100,
                                 "accuracy": 2
                             },
                             {
                                 "measurement": "Temperature",
-                                "measure_unit": "°C",
+                                "unit": "°C",
                                 "min": -40,
                                 "max": 125,
                                 "accuracy": 0.5
@@ -383,14 +383,14 @@
                         "measuring_quantity": [
                             {
                                 "measurement": "Pressure",
-                                "measure_unit": "kPa",
+                                "unit": "kPa",
                                 "min": 0,
                                 "max": 400,
                                 "accuracy": 1
                             },
                             {
                                 "measurement": "Temperature",
-                                "measure_unit": "°C",
+                                "unit": "°C",
                                 "min": -50,
                                 "max": 150,
                                 "accuracy": 5

--- a/examples/static/embedded_sensornet.json
+++ b/examples/static/embedded_sensornet.json
@@ -6,240 +6,415 @@
                 "node_id": "0x00",
                 "hw_version": "2.2.1",
                 "manufacturer": "BAM",
-                "devices": [
+                "sensors": [
                     {
-                        "measurement": "Relative Humidity",
+                        "sensor_id": "0x27",
                         "product_name": "HIH8130-021-001",
-                        "measure_unit": "%RH",
-                        "min": 0,
-                        "max": 100,
-                        "accuracy": 2
+                        "measuring_quantity": [
+                            {
+                                "measurement": "Relative Humidity",
+                                "measure_unit": "%RH",
+                                "min": 0,
+                                "max": 100,
+                                "accuracy": 2
+                            },
+                            {
+                                "measurement": "Temperature",
+                                "measure_unit": "°C",
+                                "min": -40,
+                                "max": 125,
+                                "accuracy": 0.5
+                            }
+                        ],
+                        "calibration": {
+                            "date": "24.01.2023",
+                            "certificate": "BAM department 8.1"
+                        },
+                        "pose": {
+                            "body_frame": "",
+                            "rotation_order": "XYZ",
+                            "position": [
+                                0,
+                                0,
+                                0
+                            ],
+                            "orientation": [
+                                0,
+                                0,
+                                0
+                            ]
+                        }
                     },
                     {
-                        "measurement": "Temperature",
-                        "product_name": "HIH8130-021-001",
-                        "measure_unit": "°C",
-                        "min": -40,
-                        "max": 125,
-                        "accuracy": 0.5
-                    },
-                    {
-                        "measurement": "Pressure",
+                        "sensor_id": "0x28",
                         "product_name": "ABP2LNNT400KA2A3XX",
-                        "measure_unit": "kPa",
-                        "min": 0,
-                        "max": 400,
-                        "accuracy": 1
-                    },
-                    {
-                        "measurement": "Temperature",
-                        "product_name": "ABP2LNNT400KA2A3XX",
-                        "measure_unit": "°C",
-                        "min": -50,
-                        "max": 150,
-                        "accuracy": 5
+                        "measuring_quantity": [
+                            {
+                                "measurement": "Pressure",
+                                "measure_unit": "kPa",
+                                "min": 0,
+                                "max": 400,
+                                "accuracy": 1
+                            },
+                            {
+                                "measurement": "Temperature",
+                                "measure_unit": "°C",
+                                "min": -50,
+                                "max": 150,
+                                "accuracy": 5
+                            }
+                        ],
+                        "calibration": {
+                            "date": "24.01.2023",
+                            "certificate": "BAM department 8.1"
+                        },
+                        "pose": {
+                            "body_frame": "",
+                            "rotation_order": "XYZ",
+                            "position": [
+                                0,
+                                0,
+                                0
+                            ],
+                            "orientation": [
+                                0,
+                                0,
+                                0
+                            ]
+                        }
                     }
-                ],
-                "calibration": {
-                    "date": "24.01.2023",
-                    "certificate": "BAM department 8.1"
-                },
-                "location": [
-                    0.297,
-                    0,
-                    0.80
                 ]
             },
             {
                 "node_id": "0x01",
                 "hw_version": "2.2.1",
                 "manufacturer": "BAM",
-                "devices": [
+                "sensors": [
                     {
-                        "measurement": "Relative Humidity",
+                        "sensor_id": "0x26",
                         "product_name": "HIH8130-021-001",
-                        "measure_unit": "%RH",
-                        "min": 0,
-                        "max": 100,
-                        "accuracy": 2
+                        "measuring_quantity": [
+                            {
+                                "measurement": "Relative Humidity",
+                                "measure_unit": "%RH",
+                                "min": 0,
+                                "max": 100,
+                                "accuracy": 2
+                            },
+                            {
+                                "measurement": "Temperature",
+                                "measure_unit": "°C",
+                                "min": -40,
+                                "max": 125,
+                                "accuracy": 0.5
+                            }
+                        ],
+                        "calibration": {
+                            "date": "24.01.2023",
+                            "certificate": "BAM department 8.1"
+                        },
+                        "pose": {
+                            "body_frame": "",
+                            "rotation_order": "XYZ",
+                            "position": [
+                                0,
+                                0,
+                                0
+                            ],
+                            "orientation": [
+                                0,
+                                0,
+                                0
+                            ]
+                        }
                     },
                     {
-                        "measurement": "Temperature",
-                        "product_name": "HIH8130-021-001",
-                        "measure_unit": "°C",
-                        "min": -40,
-                        "max": 125,
-                        "accuracy": 0.5
-                    },
-                    {
-                        "measurement": "Pressure",
+                        "sensor_id": "0x29",
                         "product_name": "ABP2LNNT400KA2A3XX",
-                        "measure_unit": "kPa",
-                        "min": 0,
-                        "max": 400,
-                        "accuracy": 1
-                    },
-                    {
-                        "measurement": "Temperature",
-                        "product_name": "ABP2LNNT400KA2A3XX",
-                        "measure_unit": "°C",
-                        "min": -50,
-                        "max": 150,
-                        "accuracy": 5
+                        "measuring_quantity": [
+                            {
+                                "measurement": "Pressure",
+                                "measure_unit": "kPa",
+                                "min": 0,
+                                "max": 400,
+                                "accuracy": 1
+                            },
+                            {
+                                "measurement": "Temperature",
+                                "measure_unit": "°C",
+                                "min": -50,
+                                "max": 150,
+                                "accuracy": 5
+                            }
+                        ],
+                        "calibration": {
+                            "date": "24.01.2023",
+                            "certificate": "BAM department 8.1"
+                        },
+                        "pose": {
+                            "body_frame": "",
+                            "rotation_order": "XYZ",
+                            "position": [
+                                0,
+                                0,
+                                0
+                            ],
+                            "orientation": [
+                                0,
+                                0,
+                                0
+                            ]
+                        }
                     }
-                ],
-                "calibration": {
-                    "date": "24.01.2023",
-                    "certificate": "BAM department 8.1"
-                },
-                "location": [
-                    0.297,
-                    0,
-                    0.4
                 ]
             },
             {
                 "node_id": "0x02",
                 "hw_version": "2.2.1",
                 "manufacturer": "BAM",
-                "devices": [
+                "sensors": [
                     {
-                        "measurement": "Relative Humidity",
+                        "sensor_id": "0x25",
                         "product_name": "HIH8130-021-001",
-                        "measure_unit": "%RH",
-                        "min": 0,
-                        "max": 100,
-                        "accuracy": 2
+                        "measuring_quantity": [
+                            {
+                                "measurement": "Relative Humidity",
+                                "measure_unit": "%RH",
+                                "min": 0,
+                                "max": 100,
+                                "accuracy": 2
+                            },
+                            {
+                                "measurement": "Temperature",
+                                "measure_unit": "°C",
+                                "min": -40,
+                                "max": 125,
+                                "accuracy": 0.5
+                            }
+                        ],
+                        "calibration": {
+                            "date": "24.01.2023",
+                            "certificate": "BAM department 8.1"
+                        },
+                        "pose": {
+                            "body_frame": "",
+                            "rotation_order": "XYZ",
+                            "position": [
+                                0,
+                                0,
+                                0
+                            ],
+                            "orientation": [
+                                0,
+                                0,
+                                0
+                            ]
+                        }
                     },
                     {
-                        "measurement": "Temperature",
-                        "product_name": "HIH8130-021-001",
-                        "measure_unit": "°C",
-                        "min": -40,
-                        "max": 125,
-                        "accuracy": 0.5
-                    },
-                    {
-                        "measurement": "Pressure",
+                        "sensor_id": "0x2A",
                         "product_name": "ABP2LNNT400KA2A3XX",
-                        "measure_unit": "kPa",
-                        "min": 0,
-                        "max": 400,
-                        "accuracy": 1
-                    },
-                    {
-                        "measurement": "Temperature",
-                        "product_name": "ABP2LNNT400KA2A3XX",
-                        "measure_unit": "°C",
-                        "min": -50,
-                        "max": 150,
-                        "accuracy": 5
+                        "measuring_quantity": [
+                            {
+                                "measurement": "Pressure",
+                                "measure_unit": "kPa",
+                                "min": 0,
+                                "max": 400,
+                                "accuracy": 1
+                            },
+                            {
+                                "measurement": "Temperature",
+                                "measure_unit": "°C",
+                                "min": -50,
+                                "max": 150,
+                                "accuracy": 5
+                            }
+                        ],
+                        "calibration": {
+                            "date": "24.01.2023",
+                            "certificate": "BAM department 8.1"
+                        },
+                        "pose": {
+                            "body_frame": "",
+                            "rotation_order": "XYZ",
+                            "position": [
+                                0,
+                                0,
+                                0
+                            ],
+                            "orientation": [
+                                0,
+                                0,
+                                0
+                            ]
+                        }
                     }
-                ],
-                "calibration": {
-                    "date": "24.01.2023",
-                    "certificate": "BAM department 8.1"
-                },
-                "location": [
-                    0.297,
-                    2.09,
-                    0.4
                 ]
             },
             {
                 "node_id": "0x03",
                 "hw_version": "2.2.1",
                 "manufacturer": "BAM",
-                "devices": [
+                "sensors": [
                     {
-                        "measurement": "Relative Humidity",
+                        "sensor_id": "0x24",
                         "product_name": "HIH8130-021-001",
-                        "measure_unit": "%RH",
-                        "min": 0,
-                        "max": 100,
-                        "accuracy": 2
+                        "measuring_quantity": [
+                            {
+                                "measurement": "Relative Humidity",
+                                "measure_unit": "%RH",
+                                "min": 0,
+                                "max": 100,
+                                "accuracy": 2
+                            },
+                            {
+                                "measurement": "Temperature",
+                                "measure_unit": "°C",
+                                "min": -40,
+                                "max": 125,
+                                "accuracy": 0.5
+                            }
+                        ],
+                        "calibration": {
+                            "date": "24.01.2023",
+                            "certificate": "BAM department 8.1"
+                        },
+                        "pose": {
+                            "body_frame": "",
+                            "rotation_order": "XYZ",
+                            "position": [
+                                0,
+                                0,
+                                0
+                            ],
+                            "orientation": [
+                                0,
+                                0,
+                                0
+                            ]
+                        }
                     },
                     {
-                        "measurement": "Temperature",
-                        "product_name": "HIH8130-021-001",
-                        "measure_unit": "°C",
-                        "min": -40,
-                        "max": 125,
-                        "accuracy": 0.5
-                    },
-                    {
-                        "measurement": "Pressure",
+                        "sensor_id": "0x2B",
                         "product_name": "ABP2LNNT400KA2A3XX",
-                        "measure_unit": "kPa",
-                        "min": 0,
-                        "max": 400,
-                        "accuracy": 1
-                    },
-                    {
-                        "measurement": "Temperature",
-                        "product_name": "ABP2LNNT400KA2A3XX",
-                        "measure_unit": "°C",
-                        "min": -50,
-                        "max": 150,
-                        "accuracy": 5
+                        "measuring_quantity": [
+                            {
+                                "measurement": "Pressure",
+                                "measure_unit": "kPa",
+                                "min": 0,
+                                "max": 400,
+                                "accuracy": 1
+                            },
+                            {
+                                "measurement": "Temperature",
+                                "measure_unit": "°C",
+                                "min": -50,
+                                "max": 150,
+                                "accuracy": 5
+                            }
+                        ],
+                        "calibration": {
+                            "date": "24.01.2023",
+                            "certificate": "BAM department 8.1"
+                        },
+                        "pose": {
+                            "body_frame": "",
+                            "rotation_order": "XYZ",
+                            "position": [
+                                0,
+                                0,
+                                0
+                            ],
+                            "orientation": [
+                                0,
+                                0,
+                                0
+                            ]
+                        }
                     }
-                ],
-                "calibration": {
-                    "date": "24.01.2023",
-                    "certificate": "BAM department 8.1"
-                },
-                "location": [
-                    0.297,
-                    4.71,
-                    0.4
                 ]
             },
             {
                 "node_id": "0x04",
                 "hw_version": "2.2.1",
                 "manufacturer": "BAM",
-                "devices": [
+                "sensors": [
                     {
-                        "measurement": "Relative Humidity",
+                        "sensor_id": "0x23",
                         "product_name": "HIH8130-021-001",
-                        "measure_unit": "%RH",
-                        "min": 0,
-                        "max": 100,
-                        "accuracy": 2
+                        "measuring_quantity": [
+                            {
+                                "measurement": "Relative Humidity",
+                                "measure_unit": "%RH",
+                                "min": 0,
+                                "max": 100,
+                                "accuracy": 2
+                            },
+                            {
+                                "measurement": "Temperature",
+                                "measure_unit": "°C",
+                                "min": -40,
+                                "max": 125,
+                                "accuracy": 0.5
+                            }
+                        ],
+                        "calibration": {
+                            "date": "24.01.2023",
+                            "certificate": "BAM department 8.1"
+                        },
+                        "pose": {
+                            "body_frame": "",
+                            "rotation_order": "XYZ",
+                            "position": [
+                                0,
+                                0,
+                                0
+                            ],
+                            "orientation": [
+                                0,
+                                0,
+                                0
+                            ]
+                        }
                     },
                     {
-                        "measurement": "Temperature",
-                        "product_name": "HIH8130-021-001",
-                        "measure_unit": "°C",
-                        "min": -40,
-                        "max": 125,
-                        "accuracy": 0.5
-                    },
-                    {
-                        "measurement": "Pressure",
+                        "sensor_id": "0x2C",
                         "product_name": "ABP2LNNT400KA2A3XX",
-                        "measure_unit": "kPa",
-                        "min": 0,
-                        "max": 400,
-                        "accuracy": 1
-                    },
-                    {
-                        "measurement": "Temperature",
-                        "product_name": "ABP2LNNT400KA2A3XX",
-                        "measure_unit": "°C",
-                        "min": -50,
-                        "max": 150,
-                        "accuracy": 5
+                        "measuring_quantity": [
+                            {
+                                "measurement": "Pressure",
+                                "measure_unit": "kPa",
+                                "min": 0,
+                                "max": 400,
+                                "accuracy": 1
+                            },
+                            {
+                                "measurement": "Temperature",
+                                "measure_unit": "°C",
+                                "min": -50,
+                                "max": 150,
+                                "accuracy": 5
+                            }
+                        ],
+                        "calibration": {
+                            "date": "24.01.2023",
+                            "certificate": "BAM department 8.1"
+                        },
+                        "pose": {
+                            "body_frame": "",
+                            "rotation_order": "XYZ",
+                            "position": [
+                                0,
+                                0,
+                                0
+                            ],
+                            "orientation": [
+                                0,
+                                0,
+                                0
+                            ]
+                        }
                     }
-                ],
-                "calibration": {
-                    "date": "24.01.2023",
-                    "certificate": "BAM department 8.1"
-                },
-                "location": [
-                    0.297,
-                    0,
-                    0
                 ]
             }
         ],

--- a/examples/static/sensor.json
+++ b/examples/static/sensor.json
@@ -1,16 +1,15 @@
 {
     "comment": "this is an example of metadata for a sensor that is validated with a schema found in schemas/ folder. More fields can be added and example can be extended to cover the sensors used in predis.",
     "sensor_id": "sensor-001",
-    "package_id": "package-001",
-    "position": {
-        "location": [
+    "pose": {
+        "position": [
             0,
             1,
             0
         ]
     },
     "measuring_quantity": {
-        "type": "temperature",
+        "measurement": "Temperature",
         "unit": "K"
     }
 }

--- a/examples/static/sensor.json
+++ b/examples/static/sensor.json
@@ -8,8 +8,10 @@
             0
         ]
     },
-    "measuring_quantity": {
-        "measurement": "Temperature",
-        "unit": "K"
-    }
+    "measuring_quantity": [
+        {
+            "measurement": "Temperature",
+            "unit": "K"
+        }
+    ]
 }

--- a/schemas/static/embedded_sensornet.json
+++ b/schemas/static/embedded_sensornet.json
@@ -43,7 +43,8 @@
                                 "type": "string"
                             },
                             "sensors": {
-                                "$ref": "sensor.json"
+                                "type": "array",
+                                "items": {"$ref": "sensor.json"}
                             }
                         }
                     }

--- a/schemas/static/embedded_sensornet.json
+++ b/schemas/static/embedded_sensornet.json
@@ -27,8 +27,7 @@
                         "type": "object",
                         "required": [
                             "node_id",
-                            "devices",
-                            "location"
+                            "sensors"
                         ],
                         "properties": {
                             "node_id": {
@@ -43,68 +42,8 @@
                                 "description": "Institution/company responsible for the product.",
                                 "type": "string"
                             },
-                            "devices": {
-                                "description": "Sensors installed in each SensorNode.",
-                                "type": "array",
-                                "items": {
-                                    "type": "object",
-                                    "properties": {
-                                        "measurement": {
-                                            "description": "Quantity measured by the sensor.",
-                                            "type": "string",
-                                            "enum": [
-                                                "Relative Humidity",
-                                                "Temperature",
-                                                "Pressure"
-                                            ]
-                                        },
-                                        "product_name": {
-                                            "description": "Sensor's product code.",
-                                            "type": "string"
-                                        },
-                                        "measure_unit": {
-                                            "description": "SI measure unit.",
-                                            "type": "string"
-                                        },
-                                        "min": {
-                                            "description": "Minimum value admissible by the sensor (in SI unit measure).",
-                                            "type": "number"
-                                        },
-                                        "max": {
-                                            "description": "Maximum value admissible by the sensor (in SI unit measure).",
-                                            "type": "number"
-                                        },
-                                        "accuracy": {
-                                            "description": "Sensor's accuracy (in SI unit measure)",
-                                            "type": "number"
-                                        }
-                                    }
-                                }
-                            },
-                            "calibration": {
-                                "description": "Information about the sensor's calibration.",
-                                "type": "object",
-                                "properties": {
-                                    "date": {
-                                        "description": "Start date of the calibration procedure.",
-                                        "type": "string"
-                                    },
-                                    "certificate": {
-                                        "description": "Released certificate/code from the institute/company responsible for the calibration.",
-                                        "type": "string"
-                                    },
-                                    "notes": {
-                                        "description": "Additional notes.",
-                                        "type": "string"
-                                    }
-                                }
-                            },
-                            "location": {
-                                "description": "Position of the SensorNode inside the drum. Cylindrical coordinate system in the format [radial distance, azimuth, height] and SI measure units.",
-                                "type": "array",
-                                "items": {
-                                    "type": "number"
-                                }
+                            "sensors": {
+                                "$ref": "sensor.json"
                             }
                         }
                     }

--- a/schemas/static/embedded_sensornet.json
+++ b/schemas/static/embedded_sensornet.json
@@ -13,7 +13,7 @@
             "type": "string"
         },
         "components": {
-            "description": "Main components of the sensing system.",
+            "description": "Main components of the sensing system",
             "type": "object",
             "required": [
                 "sensornet",
@@ -67,6 +67,35 @@
                         "fw_version": {
                             "description": "Firmware version.",
                             "type": "string"
+                        }
+                    }
+                }
+            }
+        },
+        "data_format": {
+            "description": "Structure of the measurement data gathered by the system",
+            "type": "object",
+            "properties": {
+                "tag_id": {
+                    "description": "ID of the system embedded in the drum",
+                    "type": "number"
+                },
+                "utc_time": {
+                    "description": "Starting time of the measurement",
+                    "type": "number"
+                },
+                "energy_level": {
+                    "description": "Energy storage voltage at the beginning of the message uplink",
+                    "type": "number"
+                },
+                "data": {
+                    "description": "List of SensorNode's data",
+                    "type": "array",
+                    "items": {
+                        "description": "Data from a SensorNode in format: [SensorNode_ID, Humidity, Temperature, Pressure]",
+                        "type": "array",
+                        "items": {
+                            "type": "number"
                         }
                     }
                 }

--- a/schemas/static/embedded_sensornet.json
+++ b/schemas/static/embedded_sensornet.json
@@ -12,6 +12,11 @@
             "description": "Drum's unique identifier specified by the facility",
             "type": "string"
         },
+        "installation_time": {
+            "description": "Timestamp for system installation or changes.",
+            "type": "string",
+            "format": "YYYY/MM/DD hh:mm:ss"
+        },
         "components": {
             "description": "Main components of the sensing system",
             "type": "object",
@@ -44,7 +49,9 @@
                             },
                             "sensors": {
                                 "type": "array",
-                                "items": {"$ref": "sensor.json"}
+                                "items": {
+                                    "$ref": "sensor.json"
+                                }
                             }
                         }
                     }
@@ -68,35 +75,6 @@
                         "fw_version": {
                             "description": "Firmware version.",
                             "type": "string"
-                        }
-                    }
-                }
-            }
-        },
-        "data_format": {
-            "description": "Structure of the measurement data gathered by the system",
-            "type": "object",
-            "properties": {
-                "tag_id": {
-                    "description": "ID of the system embedded in the drum",
-                    "type": "number"
-                },
-                "utc_time": {
-                    "description": "Starting time of the measurement",
-                    "type": "number"
-                },
-                "energy_level": {
-                    "description": "Energy storage voltage at the beginning of the message uplink",
-                    "type": "number"
-                },
-                "data": {
-                    "description": "List of SensorNode's data",
-                    "type": "array",
-                    "items": {
-                        "description": "Data from a SensorNode in format: [SensorNode_ID, Humidity, Temperature, Pressure]",
-                        "type": "array",
-                        "items": {
-                            "type": "number"
                         }
                     }
                 }

--- a/schemas/static/sensor.json
+++ b/schemas/static/sensor.json
@@ -4,8 +4,6 @@
     "description": "Metadata for a waste package monitoring sensor, including its unique identifier, position, and measurement capabilities.",
     "type": "object",
     "required": [
-        "sensor_id",
-        "position",
         "measuring_quantity"
     ],
     "properties": {
@@ -13,26 +11,30 @@
             "description": "A unique identifier for the sensor.",
             "type": "string"
         },
-        "package_id": {
-            "description": "A unique identifier for the Waste Package where the sensor is placed.",
-            "type": "string"
-        },
-        "position": {
+        "pose": {
             "description": "The position of the sensor defined by location and optional orientation.",
             "type": "object",
             "required": [
-                "location"
+                "position"
             ],
             "properties": {
-                "location": {
-                    "description": "The XYZ coordinates of the sensor.",
+                "body_frame": {
+                    "description": "<link/to/picture>",
+                    "type": "string"
+                },
+                "rotation_order": {
+                    "description": "Axis order in which the rotations are applied.",
+                    "type": "string"
+                },
+                "position": {
+                    "description": "Origin of the body frame with respect to the fixed reference frame ([x,y,z] displacements expressed in meters).",
                     "type": "array",
                     "items": {
                         "type": "number"
                     }
                 },
                 "orientation": {
-                    "description": "The XYZ coordinates of the orientation.",
+                    "description": "Euler angles of the body frame with respect to the fixed reference frame before the translation (rotations expressed in decimal degrees about [x,y,z] axis).",
                     "type": "array",
                     "items": {
                         "type": "number"
@@ -40,33 +42,64 @@
                 }
             }
         },
+        "product_name": {
+            "description": "Sensor's product code.",
+            "type": "string"
+        },
         "measuring_quantity": {
-            "description": "The type of measurement that the sensor is capable of taking.",
-            "type": "object",
-            "required": [
-                "type",
-                "unit"
-            ],
-            "properties": {
-                "type": {
-                    "type": "string",
-                    "enum": [
-                        "temperature",
-                        "displacement",
-                        "radioactivity",
-                        "relative_humidity"
-                    ]
-                },
-                "unit": {
-                    "description": "SI unit.",
-                    "type": "string"
-                },
-                "values": {
-                    "description": "List of measured values",
-                    "type": "array",
-                    "items": {
+            "description": "The type of measurement that the sensor is capable to get.",
+            "type": "array",
+            "items": {
+                "type": "object",
+                "required": [
+                    "measurement",
+                    "measure_unit"
+                ],
+                "properties": {
+                    "measurement": {
+                        "type": "string",
+                        "enum": [
+                            "Temperature",
+                            "Displacement",
+                            "Radioactivity",
+                            "Relative Humidity",
+                            "Pressure"
+                        ]
+                    },
+                    "measure_unit": {
+                        "description": "SI measure unit.",
+                        "type": "string"
+                    },
+                    "min": {
+                        "description": "Minimum value admissible by the sensor (in SI unit measure).",
+                        "type": "number"
+                    },
+                    "max": {
+                        "description": "Maximum value admissible by the sensor (in SI unit measure).",
+                        "type": "number"
+                    },
+                    "accuracy": {
+                        "description": "Sensor's accuracy (in SI unit measure)",
                         "type": "number"
                     }
+                }
+            }
+        },
+        "calibration": {
+            "description": "Information about the sensor's calibration.",
+            "type": "object",
+            "properties": {
+                "date": {
+                    "description": "Start date of the calibration procedure.",
+                    "type": "string"
+                },
+                "certificate": {
+                    "description": "Released certificate/code from the institute/company responsible for the calibration.",
+                    "type": "string"
+                },
+                "notes": {
+                    "description": "Additional notes.",
+                    "type": "string"
                 }
             }
         }

--- a/schemas/static/sensor.json
+++ b/schemas/static/sensor.json
@@ -20,11 +20,10 @@
             "properties": {
                 "body_frame": {
                     "description": "<link/to/picture>",
-                    "type": "string"
-                },
-                "rotation_order": {
-                    "description": "Axis order in which the rotations are applied.",
-                    "type": "string"
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    }
                 },
                 "position": {
                     "description": "Origin of the body frame with respect to the fixed reference frame ([x,y,z] displacements expressed in meters).",
@@ -34,7 +33,7 @@
                     }
                 },
                 "orientation": {
-                    "description": "Euler angles of the body frame with respect to the fixed reference frame before the translation (rotations expressed in decimal degrees about [x,y,z] axis).",
+                    "description": "Euler angles of the body frame with respect to the fixed reference frame, applied in the order 'XYZ' before the translation.",
                     "type": "array",
                     "items": {
                         "type": "number"

--- a/schemas/static/sensor.json
+++ b/schemas/static/sensor.json
@@ -60,9 +60,9 @@
                         "enum": [
                             "Temperature",
                             "Displacement",
-			    "Gamma Radioactivity",
-			    "Neutron Radioactivity",
-			    "Battery Level",
+                            "Gamma Radioactivity",
+                            "Neutron Radioactivity",
+                            "Battery Level",
                             "Relative Humidity",
                             "Pressure"
                         ]
@@ -98,12 +98,13 @@
                     "description": "Released certificate/code from the institute/company responsible for the calibration.",
                     "type": "string"
                 },
-        	"factor": {
-          	    "description": "calibration factor(s).",
+                "factor": {
+                    "description": "calibration factor(s).",
                     "type": "array",
                     "items": {
-                    	"type": "string"
-          	},
+                        "type": "string"
+                    }
+                },
                 "notes": {
                     "description": "Additional notes.",
                     "type": "string"

--- a/schemas/static/sensor.json
+++ b/schemas/static/sensor.json
@@ -60,7 +60,9 @@
                         "enum": [
                             "Temperature",
                             "Displacement",
-                            "Radioactivity",
+			    "Gamma Radioactivity",
+			    "Neutron Radioactivity",
+			    "Battery Level",
                             "Relative Humidity",
                             "Pressure"
                         ]
@@ -96,6 +98,12 @@
                     "description": "Released certificate/code from the institute/company responsible for the calibration.",
                     "type": "string"
                 },
+        	"factor": {
+          	    "description": "calibration factor(s).",
+                    "type": "array",
+                    "items": {
+                    	"type": "string"
+          	},
                 "notes": {
                     "description": "Additional notes.",
                     "type": "string"

--- a/schemas/static/sensor.json
+++ b/schemas/static/sensor.json
@@ -53,7 +53,7 @@
                 "type": "object",
                 "required": [
                     "measurement",
-                    "measure_unit"
+                    "unit"
                 ],
                 "properties": {
                     "measurement": {
@@ -66,7 +66,7 @@
                             "Pressure"
                         ]
                     },
-                    "measure_unit": {
+                    "unit": {
                         "description": "SI measure unit.",
                         "type": "string"
                     },

--- a/schemas/static/sensor.json
+++ b/schemas/static/sensor.json
@@ -77,8 +77,8 @@
                         "description": "Maximum value admissible by the sensor (in SI unit measure).",
                         "type": "number"
                     },
-                    "accuracy": {
-                        "description": "Sensor's accuracy (in SI unit measure)",
+                    "variance": {
+                        "description": "Average of the squared differences of the measurements from their mean value.",
                         "type": "number"
                     }
                 }

--- a/tests/schemas/static/test_embedded_sensornet.py
+++ b/tests/schemas/static/test_embedded_sensornet.py
@@ -1,0 +1,30 @@
+import pytest
+import jsonschema
+import os
+import json
+
+def test_embedded_sensornet():
+
+    # path to embedded_sensornet metadata example file
+    ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
+    embedded_sensornet_path = os.path.join(ROOT_DIR, '..', '..', '..', 'examples','static','embedded_sensornet.json' ) 
+    embedded_sensornet = json.loads(open(embedded_sensornet_path).read())
+    
+    # path to schema file
+    schema_path = os.path.join(ROOT_DIR, '..', '..', '..', 'schemas','static','embedded_sensornet.json' )
+    schema_folder = os.path.join(ROOT_DIR, '..', '..', '..', 'schemas','static/')
+    schema = json.loads(open(schema_path).read())
+
+    try:
+    # validate data against schema
+      jsonschema.validate(embedded_sensornet, schema, resolver=jsonschema.RefResolver(
+            base_uri=f"file:{schema_folder}",
+            referrer=schema,
+            ))
+      assert True, f"The data is valid according to the schema."
+    except jsonschema.exceptions.ValidationError as e:
+      assert False, f"The data is not valid. {e}"
+    except jsonschema.exceptions.SchemaError as e:
+      assert False, f"The schema is not valid. {e}"
+
+    

--- a/tests/schemas/static/test_facility.py
+++ b/tests/schemas/static/test_facility.py
@@ -1,0 +1,26 @@
+import pytest
+import jsonschema
+import os
+import json
+
+def test_facility():
+
+    # path to facility metadata example file
+    ROOT_DIR = os.path.dirname(os.path.abspath(__file__))
+    facility_path = os.path.join(ROOT_DIR, '..', '..', '..', 'examples','static','facility.json' ) 
+    facility = json.loads(open(facility_path).read())
+    
+    # path to schema file
+    schema_path = os.path.join(ROOT_DIR, '..', '..', '..', 'schemas','static','facility.json' ) 
+    schema = json.loads(open(schema_path).read())
+
+    try:
+    # validate data against schema
+      jsonschema.validate(facility, schema)
+      assert True, f"The data is valid according to the schema."
+    except jsonschema.exceptions.ValidationError as e:
+      assert False, f"The data is not valid. {e}"
+    except jsonschema.exceptions.SchemaError as e:
+      assert False, f"The schema is not valid. {e}"
+
+    


### PR DESCRIPTION
I edited the _sensor.json_ schema to be referenced by my _embedded_sensornet.json_ schema. 
Now a sensor can have multiple **measure_quantity** with more fields like min/max value. I included in the **sensor** object also the sub-objects **calibration** and I added some fields to better define the pose of the sensor (in Cartesian coordinates).

I edited accordingly the _embedded_sensronet.json_ to refer to the new object **sensor**, so also the **location** will be a property of a single sensor rather than of a node.